### PR TITLE
Updated download README

### DIFF
--- a/0.download_data/README.md
+++ b/0.download_data/README.md
@@ -1,6 +1,6 @@
 # Download JUMP-Target SQLite files from AWS
 
-In this module, we download the SQLite files from [AWS](https://cellpainting-gallery.s3.amazonaws.com/index.html#cpg0000-jump-pilot/source_4/workspace/backend/2020_11_04_CPJUMP1/).
+In this module, we download the SQLite files from [AWS](https://cellpainting-gallery.s3.amazonaws.com/index.html#cpg0000-jump-pilot/source_4/workspace/backend/2020_11_04_CPJUMP1/) with [aws-cli](https://github.com/aws/aws-cli) on Aug 10, 2023 using instructions provided from [JUMP Cell Painting Datasets](https://github.com/jump-cellpainting/datasets).
 There are 51 plates from the pilot dataset, totalling 1.1 TB of storage from the SQLite files.
 
 Firstly, we generate a manifest file in the [data folder](./data/) called [jump_dataset_location_manifest.csv](./data/jump_dataset_location_manifest.csv).

--- a/0.download_data/README.md
+++ b/0.download_data/README.md
@@ -1,7 +1,7 @@
 # Download JUMP-Target SQLite files from AWS
 
 In this module, we download the SQLite files from [AWS](https://cellpainting-gallery.s3.amazonaws.com/index.html#cpg0000-jump-pilot/source_4/workspace/backend/2020_11_04_CPJUMP1/) with [aws-cli](https://github.com/aws/aws-cli) on Aug 10, 2023 using instructions provided from [JUMP Cell Painting Datasets](https://github.com/jump-cellpainting/datasets).
-There are 51 plates from the pilot dataset, totalling 1.1 TB of storage from the SQLite files.
+There are 51 plates from the pilot dataset (cpg0000), totalling 1.1 TB of storage from the SQLite files.
 
 Firstly, we generate a manifest file in the [data folder](./data/) called [jump_dataset_location_manifest.csv](./data/jump_dataset_location_manifest.csv).
 Then, we use the [download_from_aws.sh](./download_from_aws.sh) file, which contains the bash script that will download the files from the paths in the manifest.


### PR DESCRIPTION
In this pr, I include more information on when an how the JUMP pilot dataset was downloaded. This is in response to #2, where the referenced repo in the updated README contains more information on how to access JUMP data without AWS authentication.  Please let me know if you have any suggestions.