### PR TITLE
Add `justfile` for env management and common project commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,24 @@ Specifically, the benefits of single-cell phenotyping include:
 | [3.analyze_data](./3.analyze_data/) | Analyze phenotypic predictions | We perform multiple analyses to validate the phenotypic predicted class for each perturbation compared to control |
 | [reference_plate_data](./reference_plate_data/) | Platemaps per perturbation type | This folder holds the platemap files with metadata based on perturbation type and the barcode platemap file |
 
-## Main computational environment
+## Development
 
-For all modules, we use one environment that includes all necessary packages.
+We use a [`justfile`](justfile) to specify [`just`](https://github.com/casey/just) commands for use with this project.
+Please see [`just` installation details](https://just.systems/man/en/packages.html) for configuration on your system.
+
+### Environment
+
+For all modules, we use conda environments that includes all necessary packages.
 
 To create the environment from terminal, run the code line below:
 
 ```bash
 # Make sure you are in the same directory as the environment file
 conda env create -f environment.yml
+```
+
+Alternatively, use the following `just` command
+
+```bash
+just configure-conda
 ```

--- a/README.md
+++ b/README.md
@@ -57,5 +57,5 @@ conda env create -f environment.yml
 Alternatively, use the following `just` command
 
 ```bash
-just configure-conda
+just setup-conda-envs
 ```

--- a/justfile
+++ b/justfile
@@ -3,19 +3,32 @@
 
 # find system default shell
 hashbang := if os() == 'macos' {
-	'#!/usr/bin/env zsh'
+	'/usr/bin/env zsh'
 } else {
-	'#!/usr/bin/env bash'
+	'/usr/bin/env bash'
 }
 
 # show a list of just commands for this project
 default:
   @just --list
 
-# setup conda envs
+# setup conda envs for this project
 @setup-conda-envs:
     #!{{hashbang}}
-    conda remove -n jump_sc --all
-    conda remove -n R_jump_sc --all
-    conda env create -n jump_sc -f environment.yml
-    conda env create -n R_jump_sc -f R_environment.yml
+    # Check if the 'jump_sc' environment exists, and update or create accordingly
+    if conda env list | grep -q 'jump_sc'; then
+        echo "Updating 'jump_sc' environment"
+        conda env update -n jump_sc -f environment.yml --prune
+    else
+        echo "Creating 'jump_sc' environment"
+        conda env create -n jump_sc -f environment.yml
+    fi
+
+    # Check if the 'R_jump_sc' environment exists, and update or create accordingly
+    if conda env list | grep -q 'R_jump_sc'; then
+        echo "Updating 'R_jump_sc' environment"
+        conda env update -n R_jump_sc -f R_environment.yml --prune
+    else
+        echo "Creating 'R_jump_sc' environment"
+        conda env create -n R_jump_sc -f R_environment.yml
+    fi

--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+# justfile for common project commands
+# see here for more information: https://github.com/casey/just
+
+# find system default shell
+hashbang := if os() == 'macos' {
+	'#!/usr/bin/env zsh'
+} else {
+	'#!/usr/bin/env bash'
+}
+
+# show a list of just commands for this project
+default:
+  @just --list
+
+# setup conda envs
+@setup-conda-envs:
+    #!{{hashbang}}
+    conda remove -n jump_sc --all
+    conda remove -n R_jump_sc --all
+    conda env create -n jump_sc -f environment.yml
+    conda env create -n R_jump_sc -f R_environment.yml


### PR DESCRIPTION
This PR adds a `justfile` which may be used through [`just`](https://github.com/casey/just) for performing common project commands. I'm adding this to help account for changes over time and to save time when it comes to documentation + reproducibility of the project. I expect to expand this file with other commands but wanted to start with existing needs first and get early input on the format / usage.

Thanks for any thoughts or feedback you may have!